### PR TITLE
Fixes, JWTs, and sub Commands

### DIFF
--- a/go/build.go
+++ b/go/build.go
@@ -19,8 +19,10 @@ var build = cli.Command[*config.Config]{ //nolint:gochecknoglobals
 		source := args[1]
 		destination := args[2]
 
-		c.Vars["buildDir"] = filepath.Dir(source)
-		c.Vars["buildPath"] = source
+		c.Vars["dstDir"] = filepath.Dir(destination)
+		c.Vars["dstPath"] = destination
+		c.Vars["srcDir"] = filepath.Dir(source)
+		c.Vars["srcPath"] = source
 
 		p, err := pattern.ParsePatternFromPath(ctx, c, "", source)
 		if err != nil {

--- a/go/commands/command_test.go
+++ b/go/commands/command_test.go
@@ -18,6 +18,7 @@ func TestCommandRun(t *testing.T) {
 		env          types.EnvVars
 		execOverride bool
 		mockErrs     []error
+		parentID     string
 		remove       bool
 		wantErr      error
 		wantEnv      types.EnvVars
@@ -35,7 +36,8 @@ func TestCommandRun(t *testing.T) {
 			mockErrs: []error{
 				ErrCommandsSelfTarget,
 			},
-			remove: true,
+			parentID: "test",
+			remove:   true,
 			wantEnv: types.EnvVars{
 				"a":           "output",
 				"a_CHECK":     "0",
@@ -47,9 +49,10 @@ func TestCommandRun(t *testing.T) {
 				},
 			},
 			wantOutput: Output{
-				Check:   "output",
-				Checked: true,
-				ID:      "a",
+				Check:    "output",
+				Checked:  true,
+				ID:       "a",
+				ParentID: "test",
 			},
 		},
 		"remove_no_remove": {
@@ -421,9 +424,14 @@ func TestCommandRun(t *testing.T) {
 			c.RunMockErrors(tc.mockErrs)
 			c.RunMockOutputs([]string{"output", "output2"})
 
-			out, env, err := tc.cmd.Run(ctx, c, tc.env, Exec{
+			out, env, err := tc.cmd.Run(ctx, c, Exec{
 				AllowOverride: tc.execOverride,
-			}, tc.check, tc.remove)
+			}, CommandRunOpts{
+				Check:    tc.check,
+				Env:      tc.env,
+				ParentID: tc.parentID,
+				Remove:   tc.remove,
+			})
 
 			assert.Equal(t, out, &tc.wantOutput)
 			assert.Equal(t, env, tc.wantEnv)

--- a/go/commands/exec.go
+++ b/go/commands/exec.go
@@ -8,6 +8,7 @@ import (
 	"github.com/candiddev/shared/go/cli"
 	"github.com/candiddev/shared/go/errs"
 	"github.com/candiddev/shared/go/logger"
+	"github.com/candiddev/shared/go/types"
 )
 
 var (
@@ -16,22 +17,22 @@ var (
 
 // Exec configures top-level Exec options.
 type Exec struct {
-	AllowOverride       bool     `json:"allowOverride"`
-	Command             string   `json:"command"`
-	ContainerEntrypoint string   `json:"containerEntrypoint"`
-	ContainerImage      string   `json:"containerImage"`
-	ContainerNetwork    string   `json:"containerNetwork"`
-	ContainerPrivileged bool     `json:"containerPrivileged"`
-	ContainerPull       string   `json:"containerPull"`
-	ContainerUser       string   `json:"containerUser"`
-	ContainerVolumes    []string `json:"containerVolumes"`
-	ContainerWorkDir    string   `json:"containerWorkDir"`
-	Env                 []string `json:"env"`
-	EnvInherit          bool     `json:"envInherit"`
-	Group               string   `json:"group"`
-	Sudo                bool     `json:"sudo"`
-	User                string   `json:"user"`
-	WorkDir             string   `json:"workDir"`
+	AllowOverride       bool          `json:"allowOverride"`
+	Command             string        `json:"command"`
+	ContainerEntrypoint string        `json:"containerEntrypoint"`
+	ContainerImage      string        `json:"containerImage"`
+	ContainerNetwork    string        `json:"containerNetwork"`
+	ContainerPrivileged bool          `json:"containerPrivileged"`
+	ContainerPull       string        `json:"containerPull"`
+	ContainerUser       string        `json:"containerUser"`
+	ContainerVolumes    []string      `json:"containerVolumes"`
+	ContainerWorkDir    string        `json:"containerWorkDir"`
+	Env                 types.EnvVars `json:"env"`
+	EnvInherit          bool          `json:"envInherit"`
+	Group               string        `json:"group"`
+	Sudo                bool          `json:"sudo"`
+	User                string        `json:"user"`
+	WorkDir             string        `json:"workDir"`
 }
 
 // Override will return the absolute Exec from an ordered list of Execs.
@@ -86,7 +87,7 @@ func (e *Exec) Run(ctx context.Context, c cli.Config, script, stdin string) (cli
 		ContainerUser:       e.ContainerUser,
 		ContainerVolumes:    e.ContainerVolumes,
 		ContainerWorkDir:    e.ContainerWorkDir,
-		Environment:         e.Env,
+		Environment:         e.Env.GetEnv(),
 		EnvironmentInherit:  e.EnvInherit,
 		Group:               e.Group,
 		NoErrorLog:          true,

--- a/go/commands/exec_test.go
+++ b/go/commands/exec_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/candiddev/shared/go/assert"
 	"github.com/candiddev/shared/go/cli"
 	"github.com/candiddev/shared/go/logger"
+	"github.com/candiddev/shared/go/types"
 )
 
 func TestExecOverride(t *testing.T) {
@@ -72,8 +73,8 @@ func TestExecRun(t *testing.T) {
 			"volume",
 		},
 		ContainerWorkDir: "work2",
-		Env: []string{
-			"hello=world",
+		Env: types.EnvVars{
+			"hello": "world",
 		},
 		WorkDir: "work1",
 	}
@@ -84,7 +85,7 @@ func TestExecRun(t *testing.T) {
 
 	inputs := c.RunMockInputs()
 
-	assert.Equal(t, inputs[0].Environment, e.Env)
+	assert.Equal(t, inputs[0].Environment, e.Env.GetEnv())
 
 	cr, _ := cli.GetContainerRuntime()
 
@@ -95,7 +96,7 @@ func TestExecRun(t *testing.T) {
 	e.Run(ctx, c, "script", "stdin")
 	inputs = c.RunMockInputs()
 
-	assert.Equal(t, inputs[0].Environment, e.Env)
+	assert.Equal(t, inputs[0].Environment, e.Env.GetEnv())
 	assert.Equal(t, inputs[0].Exec, "a long command hello world script")
 	assert.Equal(t, inputs[0].WorkDir, e.WorkDir)
 }

--- a/go/commands/outputs.go
+++ b/go/commands/outputs.go
@@ -17,6 +17,7 @@ type Output struct {
 	CheckFailRemove bool
 	Events          []string
 	ID              string
+	ParentID        string
 	Remove          cli.CmdOutput
 	Removed         bool
 	RemoveFail      bool

--- a/go/commands/test.go
+++ b/go/commands/test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"regexp"
 
 	"github.com/candiddev/shared/go/cli"
 	"github.com/candiddev/shared/go/types"
@@ -16,11 +17,13 @@ const (
 )
 
 // Test runs Commands in Test mode.
-func (cmds Commands) Test(ctx context.Context, c cli.Config, exec *Exec, runEnv types.EnvVars) types.Results { //nolint:gocognit
+func (cmds Commands) Test(ctx context.Context, c cli.Config, exec *Exec, parentIDFilter *regexp.Regexp) types.Results { //nolint:gocognit
 	r := types.Results{}
 
 	// Run everything
-	outChange, _ := cmds.Run(ctx, c, runEnv, exec, false, false)
+	outChange, _ := cmds.Run(ctx, c, exec, CommandsRunOpts{
+		ParentIDFilter: parentIDFilter,
+	})
 	changes := []string{}
 	removes := []string{}
 
@@ -35,7 +38,10 @@ func (cmds Commands) Test(ctx context.Context, c cli.Config, exec *Exec, runEnv 
 	}
 
 	// Run check
-	outCheck, _ := cmds.Run(ctx, c, runEnv, exec, true, false)
+	outCheck, _ := cmds.Run(ctx, c, exec, CommandsRunOpts{
+		Check:          true,
+		ParentIDFilter: parentIDFilter,
+	})
 
 	for _, o := range outCheck {
 		for j := range changes {
@@ -46,7 +52,10 @@ func (cmds Commands) Test(ctx context.Context, c cli.Config, exec *Exec, runEnv 
 	}
 
 	// Run remove
-	outRemove, _ := cmds.Run(ctx, c, runEnv, exec, false, true)
+	outRemove, _ := cmds.Run(ctx, c, exec, CommandsRunOpts{
+		ParentIDFilter: parentIDFilter,
+		Remove:         true,
+	})
 
 	for _, o := range outRemove {
 		if o.Removed && o.Checked {
@@ -59,7 +68,11 @@ func (cmds Commands) Test(ctx context.Context, c cli.Config, exec *Exec, runEnv 
 	}
 
 	// Run check remove
-	outCheck, _ = cmds.Run(ctx, c, runEnv, exec, true, true)
+	outCheck, _ = cmds.Run(ctx, c, exec, CommandsRunOpts{
+		Check:          true,
+		ParentIDFilter: parentIDFilter,
+		Remove:         true,
+	})
 
 	for _, o := range outCheck {
 		for j := range removes {
@@ -70,7 +83,10 @@ func (cmds Commands) Test(ctx context.Context, c cli.Config, exec *Exec, runEnv 
 	}
 
 	// Run check again
-	outCheck, _ = cmds.Run(ctx, c, runEnv, exec, true, false)
+	outCheck, _ = cmds.Run(ctx, c, exec, CommandsRunOpts{
+		Check:          true,
+		ParentIDFilter: parentIDFilter,
+	})
 
 	for _, o := range outCheck {
 		for j := range changes {

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -77,7 +77,6 @@ type Source struct {
 	NoRestore         bool                                        `json:"noRestore"`
 	PullIgnoreVersion bool                                        `json:"pullIgnoreVersion"`
 	PullPaths         types.SliceString                           `json:"pullPaths"`
-	RunAll            bool                                        `json:"runAll"`
 	RunFrequencySec   int                                         `json:"runFrequencySec"`
 	RunMulti          bool                                        `json:"runMulti"`
 	TriggerOnly       bool                                        `json:"triggerOnly"`
@@ -156,9 +155,13 @@ func (c *Config) ParseJWT(ctx context.Context, customClaims any, token string, s
 	var t *jwt.Token
 
 	if len(vc) > 0 {
-		out, e := vc.Run(ctx, c.CLI, types.EnvVars{
+		ve.Env = types.EnvVars{
 			"ETCHA_JWT": token,
-		}, ve, false, false)
+		}
+
+		out, e := vc.Run(ctx, c.CLI, ve, commands.CommandsRunOpts{
+			ParentID: fmt.Sprintf("%s > verifyCommands", source),
+		})
 		if e != nil {
 			return key, r, e
 		}

--- a/go/copy.go
+++ b/go/copy.go
@@ -27,7 +27,7 @@ var copyCmd = cli.Command[*config.Config]{ //nolint:gochecknoglobals
 		"dst path or - for stdout",
 	},
 	Run: func(ctx context.Context, args []string, _ cli.Flags, config *config.Config) errs.Err {
-		mode, e := parseMode(args[1], true)
+		mode, e := parseMode(args[1])
 		if e != nil {
 			return logger.Error(ctx, e)
 		}

--- a/go/helpers.go
+++ b/go/helpers.go
@@ -119,7 +119,7 @@ func dirFileRun(file bool, usage string) cli.Command[*config.Config] { //nolint:
 		},
 		Run: func(ctx context.Context, args []string, flags cli.Flags, _ *config.Config) errs.Err {
 			dir := args[0] == "dir"
-			mode, e := parseMode(args[1], true)
+			mode, e := parseMode(args[1])
 			if e != nil {
 				return logger.Error(ctx, e)
 			}
@@ -223,13 +223,9 @@ func dirFileRun(file bool, usage string) cli.Command[*config.Config] { //nolint:
 	}
 }
 
-func parseMode(mode string, check bool) (metrics.CommandMode, errs.Err) {
+func parseMode(mode string) (metrics.CommandMode, errs.Err) {
 	switch mode {
 	case "check":
-		if !check {
-			break
-		}
-
 		return metrics.CommandModeCheck, nil
 	case "change":
 		return metrics.CommandModeChange, nil

--- a/go/initdir/lib/etcha/systemdNetwork.libsonnet
+++ b/go/initdir/lib/etcha/systemdNetwork.libsonnet
@@ -4,15 +4,18 @@ local file = import './file.libsonnet';
 local systemdUnit = import './systemdUnit.libsonnet';
 
 function(enable=true, expand=false, files, path='/etc/systemd/network', restart=true)
-  [
-    [
-      file(contents=files[f], expand=expand, group='systemd-network', mode='0600', owner='systemd-network', path='%s/%s' % [path, f]) + if restart then {
-        onChange: [
-          'systemctl restart systemd-networkd',
-        ],
-      } else {}
+  {
+    id: 'systemdNetwork',
+    commands: [
+      [
+        file(contents=files[f], expand=expand, group='systemd-network', mode='0600', owner='systemd-network', path='%s/%s' % [path, f]) + if restart then {
+          onChange: [
+            'systemctl restart systemd-networkd',
+          ],
+        } else {}
 
-      for f in std.objectFields(files)
+        for f in std.objectFields(files)
+      ],
+      systemdUnit(enable=enable, name='systemd-networkd'),
     ],
-    systemdUnit(enable=enable, name='systemd-networkd'),
-  ]
+  }

--- a/go/initdir/lib/etcha/systemdUnit.libsonnet
+++ b/go/initdir/lib/etcha/systemdUnit.libsonnet
@@ -17,28 +17,33 @@ function(contents='', dir='/etc/systemd/system', enable=true, name, reload=true,
     },
   ];
 
-  systemd + (
-    if reload then [
-      {
-        id: 'systemctl daemon-reload %s' % name,
-        change: 'systemctl daemon-reload',
-      },
-    ] else []
-  ) + (
-    if enable then [
-      {
-        change: 'systemctl enable --now %s' % name,
-        check: 'systemctl is-enabled %s' % name,
-        id: 'systemctl enable %s' % name,
-        remove: 'systemctl disable --now %s' % name,
-      },
-    ] else []
-  ) + (
-    if restart then [
-      {
-        change: 'systemctl restart %s' % name,
-        id: 'systemctl restart %s' % name,
-        remove: 'systemctl stop %s' % name,
-      },
-    ] else []
-  )
+  {
+    id: 'systemdUnit %s' % name,
+    commands: [
+      systemd + (
+        if reload then [
+          {
+            id: 'systemctl daemon-reload %s' % name,
+            change: 'systemctl daemon-reload',
+          },
+        ] else []
+      ) + (
+        if enable then [
+          {
+            change: 'systemctl enable --now %s' % name,
+            check: 'systemctl is-enabled %s' % name,
+            id: 'systemctl enable %s' % name,
+            remove: 'systemctl disable --now %s' % name,
+          },
+        ] else []
+      ) + (
+        if restart then [
+          {
+            change: 'systemctl restart %s' % name,
+            id: 'systemctl restart %s' % name,
+            remove: 'systemctl stop %s' % name,
+          },
+        ] else []
+      ),
+    ],
+  }

--- a/go/initdir/lib_test.go
+++ b/go/initdir/lib_test.go
@@ -58,18 +58,22 @@ func TestLib(t *testing.T) {
 
 	os.WriteFile("lib/etcha/native.libsonnet", []byte(jsonnet.Native), 0600)
 
-	res, err := pattern.Lint(ctx, c, ".", true)
-	assert.HasErr(t, err, nil)
+	t.Run("lint", func(t *testing.T) {
+		res, err := pattern.Lint(ctx, c, ".", true)
+		assert.HasErr(t, err, nil)
 
-	if len(res) != 0 {
-		t.Errorf(strings.Join(res.Show(), "\n"))
-	}
+		if len(res) != 0 {
+			t.Errorf(strings.Join(res.Show(), "\n"))
+		}
 
-	os.Remove("lib/etcha/native.libsonnet")
+		os.Remove("lib/etcha/native.libsonnet")
+	})
 
-	p, err := pattern.ParsePatternFromImports(ctx, c, "", &i, nil)
-	assert.HasErr(t, err, nil)
+	t.Run("test", func(t *testing.T) {
+		p, err := pattern.ParsePatternFromImports(ctx, c, "", &i, nil)
+		assert.HasErr(t, err, nil)
 
-	res = p.Test(ctx, c, false)
-	assert.Equal(t, res, types.Results{})
+		res := p.Test(ctx, c, false, nil)
+		assert.Equal(t, res, types.Results{})
+	})
 }

--- a/go/initdir/patterns/lib_test.jsonnet
+++ b/go/initdir/patterns/lib_test.jsonnet
@@ -109,9 +109,9 @@ local user = import '../lib/etcha/user.libsonnet';
   runExec: {
     allowOverride: true,
     command: std.native('getConfig')().exec.command,
-    env: [
-      'HOMEDIR=/root',
-    ],
+    env: {
+      HOMEDIR: '/root',
+    },
     envInherit: true,
     sudo: true,
   },

--- a/go/line.go
+++ b/go/line.go
@@ -22,7 +22,7 @@ var line = cli.Command[*config.Config]{ //nolint:gochecknoglobals
 		"replacement text",
 	},
 	Run: func(ctx context.Context, args []string, _ cli.Flags, config *config.Config) errs.Err {
-		mode, e := parseMode(args[1], true)
+		mode, e := parseMode(args[1])
 		if e != nil {
 			return logger.Error(ctx, e)
 		}

--- a/go/link.go
+++ b/go/link.go
@@ -21,7 +21,7 @@ var link = cli.Command[*config.Config]{ //nolint:gochecknoglobals
 		"dst",
 	},
 	Run: func(ctx context.Context, args []string, _ cli.Flags, config *config.Config) errs.Err {
-		mode, e := parseMode(args[1], true)
+		mode, e := parseMode(args[1])
 		if e != nil {
 			return logger.Error(ctx, e)
 		}

--- a/go/local.go
+++ b/go/local.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
+	"github.com/candiddev/etcha/go/commands"
 	"github.com/candiddev/etcha/go/config"
-	"github.com/candiddev/etcha/go/metrics"
 	"github.com/candiddev/etcha/go/pattern"
 	"github.com/candiddev/shared/go/cli"
 	"github.com/candiddev/shared/go/errs"
@@ -17,37 +17,46 @@ import (
 
 var local = cli.Command[*config.Config]{ //nolint:gochecknoglobals
 	ArgumentsRequired: []string{
-		"mode [change,remove]",
 		"pattern path (ending in .jsonnet) or Jsonnet to render",
 	},
-	ArgumentsOptional: []string{
-		"source name, default: local",
+	Flags: cli.Flags{
+		"f": {
+			Placeholder: "regexp",
+			Usage:       "Filter parent Command IDs",
+		},
+		"r": {
+			Usage: "Set mode to Remove (default: Change)",
+		},
+		"s": {
+			Default: []string{
+				"local",
+			},
+			Placeholder: "name",
+			Usage:       "Source name to use",
+		},
 	},
-	Run: func(ctx context.Context, args []string, _ cli.Flags, c *config.Config) errs.Err {
-		mode, err := parseMode(args[1], false)
-		if err != nil {
-			return logger.Error(ctx, err)
+	Run: func(ctx context.Context, args []string, flags cli.Flags, c *config.Config) errs.Err {
+		_, remove := flags.Value("r")
+		source, _ := flags.Value("s")
+
+		r, _ := flags.Value("f")
+		reg, e := regexp.Compile(r)
+		if e != nil {
+			return logger.Error(ctx, errs.ErrReceiver.Wrap(fmt.Errorf("error parsing filter: %w", e)))
 		}
 
-		if mode == metrics.CommandModeCheck {
-			return logger.Error(ctx, errs.ErrReceiver.Wrap(errors.New("check is not a supported mode, use a checkOnly source")))
-		}
-
-		source := "local"
-		if len(args) == 4 {
-			source = args[3]
-		}
+		var err errs.Err
 
 		var p *pattern.Pattern
 
-		if strings.HasSuffix(args[2], ".jsonnet") {
-			p, err = pattern.ParsePatternFromPath(ctx, c, source, args[2])
+		if strings.HasSuffix(args[1], ".jsonnet") {
+			p, err = pattern.ParsePatternFromPath(ctx, c, source, args[1])
 		} else {
 			var i *jsonnet.Imports
 
 			j := jsonnet.NewRender(ctx, nil)
 
-			i, err = j.GetString(ctx, fmt.Sprintf("{run: [%s]}", args[2]))
+			i, err = j.GetString(ctx, fmt.Sprintf("{run: [%s]}", args[1]))
 			if err != nil {
 				return logger.Error(ctx, err)
 			}
@@ -71,7 +80,12 @@ var local = cli.Command[*config.Config]{ //nolint:gochecknoglobals
 
 		s := c.Sources[source]
 
-		_, err = p.Run.Run(ctx, c.CLI, nil, p.RunExec, s != nil && s.CheckOnly, mode == "remove")
+		_, err = p.Run.Run(ctx, c.CLI, p.RunExec, commands.CommandsRunOpts{
+			Check:          s != nil && s.CheckOnly,
+			ParentID:       source,
+			ParentIDFilter: reg,
+			Remove:         remove,
+		})
 
 		return err
 	},

--- a/go/metrics/metrics.go
+++ b/go/metrics/metrics.go
@@ -43,6 +43,14 @@ func SetCommandMode(ctx context.Context, mode CommandMode) context.Context {
 	return logger.SetAttribute(ctx, "commandMode", mode)
 }
 
+func GetCommandParentID(ctx context.Context) string {
+	return logger.GetAttribute[string](ctx, "commandParentID")
+}
+
+func SetCommandParentID(ctx context.Context, parentID string) context.Context {
+	return logger.SetAttribute(ctx, "commandParentID", parentID)
+}
+
 func GetSourceName(ctx context.Context) string {
 	return logger.GetAttribute[string](ctx, "sourceName")
 }
@@ -72,7 +80,7 @@ func init() { //nolint:gochecknoinits
 			Help: "Counter of Commands that have ran",
 			Name: "etcha_commands_total",
 		},
-		[]string{"error", "id", "mode", "source"},
+		[]string{"error", "id", "mode", "source", "parentID"},
 	)
 	prometheus.MustRegister(commands)
 
@@ -96,7 +104,7 @@ func init() { //nolint:gochecknoinits
 }
 
 func CollectCommands(ctx context.Context, err bool) {
-	commands.WithLabelValues(metrics.ParseBool(err), GetCommandID(ctx), string(GetCommandMode(ctx)), GetSourceName(ctx)).Inc()
+	commands.WithLabelValues(metrics.ParseBool(err), GetCommandID(ctx), string(GetCommandMode(ctx)), GetSourceName(ctx), GetCommandParentID(ctx)).Inc()
 }
 
 func CollectSources(ctx context.Context, err bool) {

--- a/go/pattern/build.go
+++ b/go/pattern/build.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/candiddev/etcha/go/commands"
 	"github.com/candiddev/etcha/go/config"
 	"github.com/candiddev/shared/go/errs"
 	"github.com/candiddev/shared/go/logger"
@@ -22,7 +23,9 @@ func (p *Pattern) BuildRun(ctx context.Context, c *config.Config) (buildManifest
 	}
 
 	if len(p.Build) > 0 {
-		out, err := p.Build.Run(ctx, c.CLI, nil, p.BuildExec, false, false)
+		out, err := p.Build.Run(ctx, c.CLI, p.BuildExec, commands.CommandsRunOpts{
+			ParentID: "build",
+		})
 		if err != nil {
 			return "", nil, logger.Error(ctx, err)
 		}

--- a/go/pattern/diffrun_test.go
+++ b/go/pattern/diffrun_test.go
@@ -102,6 +102,7 @@ func TestPatternDiffRun(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
 				ErrBuildEmpty,
 			},
 			wantErr: ErrBuildEmpty,
@@ -112,6 +113,10 @@ func TestPatternDiffRun(t *testing.T) {
 				{
 					Environment: []string{"_CHECK=0", "_CHECK_OUT="},
 					Exec:        "checkB",
+				},
+				{
+					Environment: []string{"_CHECK=0", "_CHECK_OUT="},
+					Exec:        "checkD",
 				},
 				{
 					Environment: []string{"_CHECK=0", "_CHECK_OUT="},
@@ -132,7 +137,8 @@ func TestPatternDiffRun(t *testing.T) {
 					ID:      "b",
 				},
 				{
-					ID: "d",
+					Checked: true,
+					ID:      "d",
 				},
 				{
 					Checked:         true,
@@ -155,6 +161,10 @@ func TestPatternDiffRun(t *testing.T) {
 				},
 				{
 					Environment: []string{"_CHECK=0", "_CHECK_OUT="},
+					Exec:        "checkD",
+				},
+				{
+					Environment: []string{"_CHECK=0", "_CHECK_OUT="},
 					Exec:        "checkC",
 				},
 			},
@@ -168,7 +178,8 @@ func TestPatternDiffRun(t *testing.T) {
 					ID:      "b",
 				},
 				{
-					ID: "d",
+					Checked: true,
+					ID:      "d",
 				},
 				{
 					Checked:         true,
@@ -185,6 +196,10 @@ func TestPatternDiffRun(t *testing.T) {
 				{
 					Environment: []string{"_CHECK=0", "_CHECK_OUT="},
 					Exec:        "checkB",
+				},
+				{
+					Environment: []string{"_CHECK=0", "_CHECK_OUT="},
+					Exec:        "checkD",
 				},
 				{
 					Environment: []string{"_CHECK=0", "_CHECK_OUT="},
@@ -205,7 +220,8 @@ func TestPatternDiffRun(t *testing.T) {
 					ID:      "b",
 				},
 				{
-					ID: "d",
+					Checked: true,
+					ID:      "d",
 				},
 				{
 					ID:              "c",
@@ -224,6 +240,9 @@ func TestPatternDiffRun(t *testing.T) {
 				{
 					Environment: []string{"_CHECK=0", "_CHECK_OUT="}, Exec: "checkB",
 				},
+				{
+					Environment: []string{"_CHECK=0", "_CHECK_OUT="}, Exec: "checkD",
+				},
 			},
 			wantOutputs: commands.Outputs{
 				{
@@ -235,7 +254,8 @@ func TestPatternDiffRun(t *testing.T) {
 					ID:      "b",
 				},
 				{
-					ID: "d",
+					Checked: true,
+					ID:      "d",
 				},
 			},
 		},
@@ -289,7 +309,10 @@ func TestPatternDiffRun(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c.CLI.RunMockErrors(tc.mockError)
 
-			o, err := pNew.DiffRun(ctx, c, &pOld, tc.check, tc.noRemove, tc.runAll)
+			o, err := pNew.DiffRun(ctx, c, &pOld, DiffRunOpts{
+				Check:    tc.check,
+				NoRemove: tc.noRemove,
+			})
 
 			assert.HasErr(t, err, tc.wantErr)
 			assert.Equal(t, o, tc.wantOutputs)

--- a/go/pattern/jwt.go
+++ b/go/pattern/jwt.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"time"
 
@@ -105,6 +106,13 @@ func (j *JWT) Equal(j2 *JWT, ignoreVersion bool) error {
 
 // Pattern returns a Pattern from the JWT.
 func (j *JWT) Pattern(ctx context.Context, c *config.Config, configSource string) (*Pattern, errs.Err) {
+	vars := maps.Clone(j.EtchaRunVars)
+	if vars == nil {
+		vars = map[string]any{}
+	}
+
+	vars["jwt"] = j.Raw
+
 	p, err := ParsePatternFromImports(ctx, c, configSource, j.EtchaPattern, j.EtchaRunVars)
 	if err != nil {
 		return nil, logger.Error(ctx, err)

--- a/go/pattern/pattern_test.go
+++ b/go/pattern/pattern_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/candiddev/shared/go/cryptolib"
 	"github.com/candiddev/shared/go/jsonnet"
 	"github.com/candiddev/shared/go/logger"
+	"github.com/candiddev/shared/go/types"
 )
 
 func TestParsePatternFromImports(t *testing.T) {
@@ -232,9 +233,9 @@ local config = std.native('getConfig')();
 		t.Run(name, func(t *testing.T) {
 			c.Exec.AllowOverride = tc.override
 			c.Exec.EnvInherit = tc.envInherit
-			c.Exec.Env = []string{
-				"hello=world",
-				"a=b",
+			c.Exec.Env = types.EnvVars{
+				"hello": "world",
+				"a":     "b",
 			}
 			p, err := ParsePatternFromImports(ctx, c, tc.source, &jsonnet.Imports{
 				Entrypoint: "/main.jsonnet",

--- a/go/pattern/test_test.go
+++ b/go/pattern/test_test.go
@@ -62,11 +62,11 @@ func TestTest(t *testing.T) {
 		ErrBuildEmpty,
 	})
 
-	r, err := Test(ctx, c, "/asdfasdjzcbjzxkbjxcb", true)
+	r, err := Test(ctx, c, "/asdfasdjzcbjzxkbjxcb", true, nil)
 	assert.HasErr(t, err, errs.ErrReceiver)
 	assert.Equal(t, r, nil)
 
-	r, err = Test(ctx, c, "testdata", true)
+	r, err = Test(ctx, c, "testdata", true, nil)
 	assert.HasErr(t, err, nil)
 	assert.Equal(t, r, types.Results{
 		"testdata/main.jsonnet:a": {
@@ -75,7 +75,7 @@ func TestTest(t *testing.T) {
 		},
 	})
 
-	r, err = Test(ctx, c, "testdata/main.jsonnet", true)
+	r, err = Test(ctx, c, "testdata/main.jsonnet", true, nil)
 	assert.HasErr(t, err, nil)
 	assert.Equal(t, r, types.Results{})
 

--- a/go/test.go
+++ b/go/test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/candiddev/etcha/go/config"
@@ -22,10 +24,21 @@ var test = cli.Command[*config.Config]{ //nolint:gochecknoglobals
 		"b": {
 			Usage: "Test build commands",
 		},
+		"f": {
+			Placeholder: "regexp",
+			Usage:       "Filter parent Command IDs",
+		},
 	},
 	Run: func(ctx context.Context, args []string, flags cli.Flags, c *config.Config) errs.Err {
 		_, b := flags.Value("b")
-		l, err := pattern.Test(ctx, c, args[1], b)
+
+		r, _ := flags.Value("f")
+		reg, e := regexp.Compile(r)
+		if e != nil {
+			return logger.Error(ctx, errs.ErrReceiver.Wrap(fmt.Errorf("error parsing filter: %w", e)))
+		}
+
+		l, err := pattern.Test(ctx, c, args[1], b, reg)
 		if err != nil {
 			return err
 		}

--- a/hugo/content/blog/whats-new-202403.md
+++ b/hugo/content/blog/whats-new-202403.md
@@ -10,6 +10,21 @@ type: blog
 
 {{< etcha-release version="2024.03" >}}
 
+## Features
+
+### Sub Commands
+
+[Commands]({{< ref "/docs/references/commands" >}}) can now contain sub Commands.  These Commands are executed within their own scope for `onChange/Fail/Remove`.
+
 ## Enhancements
 
+- Changed [`exec.env`]({{< ref "/docs/references/config#env" >}}) to be a map of strings.
+- Changed [`onChange`, `onFail`, and `onRemove`]({{< ref "/docs/references/patterns#on" >}}) to support RegExp values.
+- Changed `etcha local`, `etcha push`, and `etcha test` to allow filtering for parent Command IDs for targeting and testing.
 - Changed [`etcha local`]({{< ref "/docs/references/cli#local" >}}) to support rendering and running ad-hoc Jsonnet.  See [Render and Run]({{< ref "/docs/guides/running-patterns#render-and-run" >}}) for more information.
+- Changed `etcha push` and `etcha run` to include the raw JWT as a var.
+- Fixed [`etcha lint`]({{< ref "/docs/references/cli#lint" >}}) not excluding directories correctly.
+
+## Removals
+
+- Removed [`sources.runAll`]({{< ref "/docs/references/config#runall" >}}) toggle, Patterns will always run all Commands by default.

--- a/hugo/content/docs/guides/running-patterns.md
+++ b/hugo/content/docs/guides/running-patterns.md
@@ -18,8 +18,13 @@ Given a Pattern like this:
 local app_name = 'myapp';
 local restart = function(name)
   {
-    change: 'systemctl restart %s' % name,
-    id: 'restart %s' % name,
+    id: 'my app',
+    commands: [
+      {
+        change: 'systemctl restart %s' % name,
+        id: 'restart %s' % name,
+      },
+    ],
   };
 
 {
@@ -70,8 +75,8 @@ Etcha will always perform the following during the run phase:
 
 Etcha can run Patterns via one-off applies using the [CLI]({{< ref "/docs/references/cli" >}}).  These runs will always be local to the current Etcha instance.  They're performed using the following CLI commands:
 
-- [`etcha local change [pattern path]`]({{< ref "/docs/references/cli#local" >}}), executes the `run` in [**Change Mode**]({{< ref "/docs/references/commands#change-mode" >}}).
-- [`etcha local remove [pattern path]`]({{< ref "/docs/references/cli#local" >}})), executes the `run` in [**Remove Mode**]({{< ref "/docs/references/commands#remove-mode" >}}).
+- [`etcha local [pattern path]`]({{< ref "/docs/references/cli#local" >}}), executes the `run` in [**Change Mode**]({{< ref "/docs/references/commands#change-mode" >}}).
+- [`etcha local -r [pattern path]`]({{< ref "/docs/references/cli#local" >}})), executes the `run` in [**Remove Mode**]({{< ref "/docs/references/commands#remove-mode" >}}).
 
 
 ### Render and Run
@@ -79,7 +84,7 @@ Etcha can run Patterns via one-off applies using the [CLI]({{< ref "/docs/refere
 Local can also be passed raw Jsonnet that it will wrap in a `{run: [<your jsonnet>]}` string and render a Pattern on the fly.  You can use this to run [Libraries]({{< ref "/docs/references/libraries" >}}) or test other Jsonnet things:
 
 ```bash
-$ etcha local change "(import 'lib/etcha/etchaInstall.libsonnet')(dst='/tmp/etcha')"
+$ etcha local "(import 'lib/etcha/etchaInstall.libsonnet')(dst='/tmp/etcha')"
 INFO  Changing download Etcha to /tmp/etcha...
 INFO  Always changing etcha version...
 ```

--- a/hugo/content/docs/references/cli.md
+++ b/hugo/content/docs/references/cli.md
@@ -94,7 +94,7 @@ Lint all `.jsonnet` and `.libsonnet` files in the path, checking the syntax and 
 
 ### `local`
 
-Import [Pattern]({{< ref "/docs/references/patterns" >}}) [Jsonnet]({{< ref "/docs/references/jsonnet" >}}) files from path, execute all [Commands]({{< ref "/docs/references/commands" >}}) in the specified mode locally.  Can optionally specify a [Config Source]({{< ref "/docs/references/config#sources" >}}).
+Import [Pattern]({{< ref "/docs/references/patterns" >}}) [Jsonnet]({{< ref "/docs/references/jsonnet" >}}) files from path, execute all [Commands]({{< ref "/docs/references/commands" >}}) in the specified mode locally.  Can optionally specify a [Config Source]({{< ref "/docs/references/config#sources" >}}) and a Parent ID to filter Commands with.
 
 ### `push`
 
@@ -118,4 +118,4 @@ Show the rendered pattern of a JWT or pattern file.
 
 ### `test`
 
-Test all patterns in path.  See [Testing Patterns]({{< ref "/docs/guides/testing-patterns" >}}) for more information.
+Test all patterns in path, optionally filtering for specific Command Parent IDs.  See [Testing Patterns]({{< ref "/docs/guides/testing-patterns" >}}) for more information.

--- a/hugo/content/docs/references/commands.md
+++ b/hugo/content/docs/references/commands.md
@@ -131,6 +131,10 @@ String, the commands or executable to run during [Change Mode](#change-mode).  C
 
 String, the commands or executable to run during [Change Mode](#change-mode) or [Check Mode](#check-mode).  Can be multiple lines.  Will be appended to `exec.command`.  If this returns 0, [`remove`](#remove) will be ran in [Remove Mode](#remove-mode).  If this does not return 0, [`change`](#change) will be ran in [Change Mode](#change-mode).  If omitted, [`change`](#change) or [`remove`](#remove) will never run unless [`always`](#always) is `true` or [`id`](#id) is changed by another Command via [`onChange`](#onChange) or removed by another Command via [`onRemove`](#onRemove)
 
+### `commands`
+
+A list of sub Commands.  Other properties for this Command will be ignored except `id`.  These Commands will be ran in a group and not affect other groups.
+
 ### `envPrefix`
 
 String, an environment variable name prefix to add to all [Environment Variables](#environment-variables) created by this command.  Must be a valid environment variable (does not start with a number, must only contain word characters or _).
@@ -145,7 +149,35 @@ An ID for the Command.  Must be specified.  Can overlap with other Commands.
 
 ### `onChange`, `onFail`, `onRemove` {#on}
 
-A list of other Command [`id`s](#id) to run, or a list of [Events]({{< ref "/docs/references/events" >}}) to trigger, if this Command changes, removes or fails.  Event names must be prefixed with `etcha:`.  Cannot specify the current command ID (can't target self).  For onChange, targets must exist and occur after the current Command in the Command list (onRemove is the opposite, must occur before), or there will be an error during compilation.
+A list of:
+- Other Command [`id`s](#id) to run
+- Regular expressions to match Command [`id`s](#id) to run
+- [Events]({{< ref "/docs/references/events" >}}) to trigger, if this Command changes, removes or fails.  Event names must be prefixed with `etcha:`.
+
+Cannot specify the current command ID (can't target self).  For onChange, targets must exist and occur after the current Command in the Command list (onRemove is the opposite, must occur before), or there will be an error during compilation.
+
+These IDs can only target IDs within the current Command list:
+
+```json
+[
+  {
+    id: "a",
+    commands: [
+      {
+        id: "b"
+      },
+      {
+        id: "c"
+      },
+    ],
+  },
+  {
+    id: "d"
+  }
+]
+```
+
+In this example, `b` can target `c` but cannot target `d`.
 
 ### `remove`
 

--- a/hugo/content/docs/references/config.md
+++ b/hugo/content/docs/references/config.md
@@ -186,9 +186,9 @@ String, override the WorkDir of a container.
 
 ### `env`
 
-List of strings in the format `ENVIRONMENT=value`, will set these as environment variables.
+Map of strings in the format `"ENVIRONMENT": "value"`, will set these as environment variables.
 
-**Default:** `[]`
+**Default:** `{}`
 
 ### `envInheirt`
 
@@ -423,7 +423,7 @@ See [Run > verifyCommands](#verifycommands).  Setting this value overrides `run.
 
 **Default:** `[]`
 
-## `vars`
+## `vars` {#sourcevars}
 
 A map of strings and any type of value.  Can be used during rendering to get/set values.  Will be combined with the top-level rendering--the values set here will override top-level ones.  See [Patterns - Variables]({{< ref "/docs/references/patterns#variables" >}}), [Building Patterns]({{< ref "/docs/guides/building-patterns" >}}), and [Running Patterns]({{< ref "/docs/guides/running-patterns" >}}) for more information.
 
@@ -451,15 +451,30 @@ List of HTTP paths to listen for webhooks.  See [Running Patterns]({{< ref "/doc
 
 A map of strings and any type of value.  Can be used during rendering to get/set values.  See [Patterns - Variables]({{< ref "/docs/references/patterns#variables" >}}), [Building Patterns]({{< ref "/docs/guides/building-patterns" >}}), and [Running Patterns]({{< ref "/docs/guides/running-patterns" >}}) for more information.
 
+Vars are combined in this order:
+
+- [Pattern `etchaRunVars`]({{< ref "/docs/references/patterns#runvars" >}})
+- Top level `vars` (this value)
+- [Source `vars`](#sourcevars)
+
+Vars can be retrieved in Patterns using [`getConfig`]({{< ref "/docs/references/patterns#runvars" >}}).
+
 **Default:** `{}`
 
-During a Pattern [`build`]({{< ref "/docs/guides/building-patterns" >}}), the following additional `vars` will be set: 
+The following `vars` are added to all Patterns:
+
+- `source`: String, the source name of the Pattern.
+- `test`: Boolean, will be `true` if a Pattern is in [test mode]({{< ref "/docs/guides/testing-patterns" >}}).
+
+
+During a Pattern [`build`]({{< ref "/docs/guides/building-patterns" >}}), the following additional `vars` will be set:
 
 - `dstDir`: String, the directory of the output JWT file.
 - `dstPath`: String, the path of the output JWT file.
 - `srcDir`: String, the directory of the Pattern being built.
 - `srcPath`: String, the path of the Pattern being built.
 
-During a Pattern [`test`]({{< ref "/docs/guides/testing-patterns" >}}), the following additional `vars` will be set:
+During a Pattern [`run`]{{< ref "/docs/guides/running-patterns" >}}, the following additional `vars` will be set:
 
-- `test`: Boolean, will be `true`
+- `jwt`: String, the contents of the original JWT if the Pattern was run from a JWT.
+

--- a/hugo/content/docs/references/patterns.md
+++ b/hugo/content/docs/references/patterns.md
@@ -51,7 +51,9 @@ See [`exec`]({{< ref "/docs/references/config#exec" >}}).  Specifies a custom ex
 
 ### `runVars`
 
-A map of values that will be combined with [Vars]({{< ref "/docs/references/config#vars" >}}) when the Pattern is rendered.  These are exposed using the [Jsonnet native function, `getConfig`]({{< ref "/docs/references/jsonnet#getConfig" >}}), for rendering these values during a run:
+A map of values that will be combined with [Vars]({{< ref "/docs/references/config#vars" >}}) when the Pattern is rendered.  These can be set for Patterns by specifying them in the Pattern config, or by using the [`runVar_` build event]({{ ref "/docs/references/events#runvar" }}).
+
+These are exposed using the [Jsonnet native function, `getConfig`]({{< ref "/docs/references/jsonnet#getConfig" >}}), for rendering these values during a run:
 
 ```
 {


### PR DESCRIPTION
go
- change commands/Command to have sub Commands
- change commands/Command.On* to support RegExp values
- change commands/Commands to filter sub Commands
- change run/Push to filter/check Push Commands
- fix build vars and docs mismatch
- fix commands/Exec not using real type.EnvVars
- fix multiple functions to have options arguments
- remove run/DiffExec diffing change commands